### PR TITLE
~ gemspec: Remove versioning from parallel and parser gem dependencies.

### DIFF
--- a/remind_me.gemspec
+++ b/remind_me.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'parallel', '~> 1.19.2'
-  spec.add_dependency 'parser', '~> 3.0.2.0'
+  spec.add_dependency 'parallel'
+  spec.add_dependency 'parser'
 end


### PR DESCRIPTION
This was clashing with a Rails app in which this was included. No need for the versioning!